### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   id = "paketo-buildpacks/pip"

--- a/pip_install_process_test.go
+++ b/pip_install_process_test.go
@@ -3,7 +3,6 @@ package pip_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,10 +27,10 @@ func testPipInstallProcess(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		srcLayerPath, err = ioutil.TempDir("", "pip-source")
+		srcLayerPath, err = os.MkdirTemp("", "pip-source")
 		Expect(err).NotTo(HaveOccurred())
 
-		targetLayerPath, err = ioutil.TempDir("", "pip")
+		targetLayerPath, err = os.MkdirTemp("", "pip")
 		Expect(err).NotTo(HaveOccurred())
 
 		executable = &fakes.Executable{}

--- a/site_process_test.go
+++ b/site_process_test.go
@@ -3,7 +3,6 @@ package pip_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ func testSiteProcess(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		targetLayerPath, err = ioutil.TempDir("", "pip")
+		targetLayerPath, err = os.MkdirTemp("", "pip")
 		Expect(err).NotTo(HaveOccurred())
 
 		executable = &fakes.Executable{}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
