### PR TITLE
Add support for specifying versions of Pip with format: "X.Y"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ The buildpack will do the following:
 | -------------------- | -----------
 | `$BP_PIP_VERSION` | Configure the version of pip to install. Buildpack releases (and the pip versions for each release) can be found [here](https://github.com/paketo-buildpacks/pip/releases).
 
+Note that Pip releases are of the form `X.Y` instead of `X.Y.0`, so providing
+`X.Y` will attempt to match that exact version. Providing `X.Y.Z` will select
+the exact patch version, and providing `X.Y.*` or `~X.Y` will select the latest
+patch version.
+
 ## Integration
 
 The Pip CNB provides pip as a dependency. Downstream buildpacks can require the pip

--- a/detect.go
+++ b/detect.go
@@ -2,6 +2,7 @@ package pip
 
 import (
 	"os"
+	"regexp"
 
 	"github.com/paketo-buildpacks/packit/v2"
 )
@@ -31,7 +32,7 @@ type BuildPlanMetadata struct {
 // If a version is provided via the $BP_PIP_VERSION environment variable, that
 // version of pip will be a requirement.
 func Detect() packit.DetectFunc {
-	return func(context packit.DetectContext) (packit.DetectResult, error) {
+	return func(_ packit.DetectContext) (packit.DetectResult, error) {
 
 		requirements := []packit.BuildPlanRequirement{
 			{
@@ -45,6 +46,16 @@ func Detect() packit.DetectFunc {
 		pipVersion := os.Getenv("BP_PIP_VERSION")
 
 		if pipVersion != "" {
+			// Pip releases are of the form X.Y rather than X.Y.0, so in order
+			// to support selecting the exact version X.Y we have to up-convert
+			// X.Y to X.Y.0.
+			// Otherwise X.Y would match the latest patch release
+			// X.Y.Z if it is available.
+			var xDotYPattern = regexp.MustCompile(`^\d+\.\d+$`)
+			if xDotYPattern.MatchString(pipVersion) {
+				pipVersion = pipVersion + ".0"
+			}
+
 			requirements = append(requirements, packit.BuildPlanRequirement{
 				Name: Pip,
 				Metadata: BuildPlanMetadata{

--- a/detect_test.go
+++ b/detect_test.go
@@ -14,18 +14,19 @@ import (
 func testDetect(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
-		detect packit.DetectFunc
+
+		detect        packit.DetectFunc
+		detectContext packit.DetectContext
 	)
 
 	it.Before(func() {
 		detect = pip.Detect()
+		detectContext = packit.DetectContext{}
 	})
 
 	context("detection", func() {
 		it("returns a build plan that provides pip", func() {
-			result, err := detect(packit.DetectContext{
-				WorkingDir: "/working-dir",
-			})
+			result, err := detect(detectContext)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result.Plan).To(Equal(packit.BuildPlan{
@@ -53,9 +54,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns a build plan that provides the version of pip from BP_PIP_VERSION", func() {
-				result, err := detect(packit.DetectContext{
-					WorkingDir: "/working-dir",
-				})
+				result, err := detect(detectContext)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(result.Plan).To(Equal(packit.BuildPlan{
@@ -78,6 +77,105 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 				}))
+			})
+
+			context("when the provided version is of the form X.Y", func() {
+				it.Before(func() {
+					os.Setenv("BP_PIP_VERSION", "2.11")
+				})
+
+				it("selects the version X.Y.0", func() {
+					result, err := detect(detectContext)
+
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(result.Plan).To(Equal(packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{
+							{Name: pip.Pip},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: pip.CPython,
+								Metadata: pip.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+							{
+								Name: pip.Pip,
+								Metadata: pip.BuildPlanMetadata{
+									Version:       "2.11.0",
+									VersionSource: "BP_PIP_VERSION",
+								},
+							},
+						},
+					}))
+				})
+			})
+
+			context("when the provided version is of the form X.Y.Z", func() {
+				it.Before(func() {
+					os.Setenv("BP_PIP_VERSION", "22.1.3")
+				})
+
+				it("selects the exact provided version X.Y.Z", func() {
+					result, err := detect(detectContext)
+
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(result.Plan).To(Equal(packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{
+							{Name: pip.Pip},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: pip.CPython,
+								Metadata: pip.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+							{
+								Name: pip.Pip,
+								Metadata: pip.BuildPlanMetadata{
+									Version:       "22.1.3",
+									VersionSource: "BP_PIP_VERSION",
+								},
+							},
+						},
+					}))
+				})
+			})
+
+			context("when the provided version is of some other form", func() {
+				it.Before(func() {
+					os.Setenv("BP_PIP_VERSION", "some.other")
+				})
+
+				it("selects the exact provided version", func() {
+					result, err := detect(detectContext)
+
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(result.Plan).To(Equal(packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{
+							{Name: pip.Pip},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: pip.CPython,
+								Metadata: pip.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+							{
+								Name: pip.Pip,
+								Metadata: pip.BuildPlanMetadata{
+									Version:       "some.other",
+									VersionSource: "BP_PIP_VERSION",
+								},
+							},
+						},
+					}))
+				})
 			})
 		})
 


### PR DESCRIPTION
## Summary

Pip releases have a version format of `X.Y` instead of `X.Y.0`, so this change is necessary to support specifying the exact version `X.Y` when there are also patch versions `X.Y.Z`.

Previously `X.Y` would match the latest patch of `~X.Y`, making it impossible to use `X.Y` to select the pip version `X.Y` if `X.Y.Z` also existed as a valid dependency version. Users would have to provided `X.Y.0` which is not the idiomatic upstream pip release versioning scheme.

## Use Cases
<!-- An explanation of the use cases your change enables -->

This allows a user to request pip version `X.Y` (analogous to `X.Y.0`) if there is also a version `X.Y.Z`. Without this change, providing `X.Y` would automatically find `X.Y.Z`.

The user could provide `X.Y.0` but this is not the actual version of Pip that is released, so this change brings the buildpack version resolution inline with the upstream pip version scheme.

Closes #108 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
