### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PIP Cloud Native Buildpack
-The Paketo Pip Buildpack is a Cloud Native Buildpack that installs pip into a
+The Paketo Buildpack for Pip is a Cloud Native Buildpack that installs pip into a
 layer and places it on the `PATH`.
 
 The buildpack is published for consumption at `gcr.io/paketo-buildpacks/pip` and

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/pip"
-  name = "Paketo Pip Buildpack"
+  name = "Paketo Buildpack for Pip"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Pip Buildpack' to 'Paketo Buildpack for Pip'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
