### PR TITLE
Add support for all stacks

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -21,7 +21,7 @@ api = "0.7"
     sha256 = "9181f9951f215953c31998b83fbb33f5c1d327727545da3fde077ed305ab63f7"
     source = "https://files.pythonhosted.org/packages/46/28/addd7e66bb3af799d35a5dcbb79407b591a7ed674f4efd2bd8f930c40821/pip-22.2.1.tar.gz"
     source_sha256 = "50516e47a2b79e77446f0d05649f0d53772c192571486236b1905492bfc24bac"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
+    stacks = ["*"]
     uri = "https://deps.paketo.io/pip/pip_22.2.1_linux_noarch_bionic_9181f995.tgz"
     version = "22.2.1"
 
@@ -33,7 +33,7 @@ api = "0.7"
     sha256 = "97bb6b2d79523a76aff67f93df6685117559979092572924931c010d705a4df4"
     source = "https://files.pythonhosted.org/packages/4b/30/e15b806597e67057e07a5acdc135216ccbf76a5f1681a324533b61066b0b/pip-22.2.2.tar.gz"
     source_sha256 = "3fd1929db052f056d7a998439176d3333fa1b3f6c1ad881de1885c0717608a4b"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
+    stacks = ["*"]
     uri = "https://deps.paketo.io/pip/pip_22.2.2_linux_noarch_bionic_97bb6b2d.tgz"
     version = "22.2.2"
 
@@ -43,10 +43,4 @@ api = "0.7"
     patches = 2
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-  id = "io.buildpacks.stacks.jammy"
-
-[[stacks]]
-  id = "org.cloudfoundry.stacks.cflinuxfs3"
+  id = "*"

--- a/integration.json
+++ b/integration.json
@@ -1,7 +1,8 @@
 {
   "builders": [
     "index.docker.io/paketobuildpacks/builder:buildpackless-base",
-    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest",
+    "index.docker.io/jericop/amazonlinux-builder:base"
   ],
   "cpython":"github.com/paketo-buildpacks/cpython",
   "build-plan":"github.com/paketo-community/build-plan"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This add support for all stacks. The paketo dependency will work on any stack because it is the same pip that comes pre-installed with cpython source as described [here](https://github.com/paketo-buildpacks/pip/blob/main/pip_install_process.go#L34).

## Use Cases
<!-- An explanation of the use cases your change enables -->

This is part of a larger effort to support all stacks on the python meta buildpack (see link below).

https://github.com/paketo-buildpacks/python/issues/522

The cpython buildpack has already been updated to support all stacks, which was a prerequisite. Similar to what was done in cpython, the offline integration tests are skipped for non-paketo stacks.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
