### PR TITLE
Add Dependency tests

### DIFF
--- a/dependency/Makefile
+++ b/dependency/Makefile
@@ -1,4 +1,4 @@
-.PHONY: retrieve
+.PHONY: retrieve test
 
 retrieve:
 	@cd retrieval; \
@@ -7,3 +7,8 @@ retrieve:
 	    --buildpack_toml_path=$(buildpackTomlPath) \
 		--output=$(output); \
 	rm retrieve
+
+test:
+	./test/test.sh \
+		--tarballPath $(tarballPath) \
+		--expectedVersion $(version)

--- a/dependency/test/README.md
+++ b/dependency/test/README.md
@@ -1,0 +1,32 @@
+To test locally:
+
+```shell
+# assume $output_dir is the output from the compilation step, with a tarball and a checksum in it
+
+docker run -it \
+  --volume $output_dir:/tmp/output_dir \
+  --volume $PWD:/tmp/test \
+  ubuntu:jammy \
+  bash
+
+# Now on the container
+# This is not required on Github Actions Virtual Environments
+# https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
+apt-get update && apt-get install python3 -y
+
+# Passing
+$ /tmp/test/test.sh \
+  --tarballPath /tmp/output_dir/pip_22.2.2_noarch_ff717ff0.tgz \
+  --expectedVersion 22.2.2
+tarballPath=/tmp/output_dir/pip_22.2.2_noarch_ff717ff0.tgz
+expectedVersion=22.2.2
+All tests passed!
+
+# Failing
+$ /tmp/test/test.sh \
+  --tarballPath /tmp/output_dir/pip_22.2.2_noarch_ff717ff0.tgz \
+  --expectedVersion 999.999.999
+tarballPath=/tmp/output_dir/pip_22.2.2_noarch_ff717ff0.tgz
+expectedVersion=999.999.999
+Version 22.2.2 does not match expected version 999.999.999
+```

--- a/dependency/test/test.sh
+++ b/dependency/test/test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+parent_dir="$(cd "$(dirname "$0")" && pwd)"
+
+extract_tarball() {
+  rm -rf pip
+  mkdir pip
+  tar --extract --file "${1}" \
+    --directory pip
+}
+
+check_version() {
+  expected_version="$1"
+  actual_version="$(python3 ./pip/setup.py  --version)"
+  if [[ "${actual_version}" != "${expected_version}" ]]; then
+    echo "Version ${actual_version} does not match expected version ${expected_version}"
+    exit 1
+  fi
+}
+
+main() {
+  local tarballPath expectedVersion
+  tarballPath=""
+  expectedVersion=""
+
+  while [ "${#}" != 0 ]; do
+    case "${1}" in
+      --tarballPath)
+        tarballPath="${2}"
+        shift 2
+        ;;
+
+      --expectedVersion)
+        expectedVersion="${2}"
+        shift 2
+        ;;
+
+      "")
+        shift
+        ;;
+
+      *)
+        echo "unknown argument \"${1}\""
+        exit 1
+    esac
+  done
+
+  if [[ "${tarballPath}" == "" ]]; then
+    echo "--tarballPath is required"
+    exit 1
+  fi
+
+  if [[ "${expectedVersion}" == "" ]]; then
+    echo "--expectedVersion is required"
+    exit 1
+  fi
+
+  echo "tarballPath=${tarballPath}"
+  echo "expectedVersion=${expectedVersion}"
+
+  apt-get update && apt-get install python3-setuptools -y
+
+  extract_tarball "${tarballPath}"
+  check_version "${expectedVersion}"
+
+  echo "All tests passed!"
+}
+
+main "$@"


### PR DESCRIPTION
Add Dependency tests under `dependency/test`.

See the `README` files for compilation and testing to run locally.

Taken from https://github.com/paketo-buildpacks/dep-server/tree/main/actions/test-dependency/dependency-tests/pip