### PR TITLE
Need to glob for downloaded pip tarball

### DIFF
--- a/dependency/actions/compile/entrypoint
+++ b/dependency/actions/compile/entrypoint
@@ -67,9 +67,11 @@ function main() {
     pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: wheel
     pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: setuptools
 
+    # Use globbing to detect the pip tarball
+    # https://github.com/paketo-buildpacks/pip/issues/334
     tar --extract \
       --strip-components=1 \
-      --file "pip-${version}.tar.gz"
+      --file pip-*.tar.gz
 
     tar --create \
       --gunzip \


### PR DESCRIPTION
Need to glob for downloaded pip tarball

Resolves #334 


To verify:

```shell
cd dependency/actions/compile
docker build --tag compilation-noarch --file noarch.Dockerfile .
output_dir=$(mktemp -d)

docker run --volume $output_dir:/tmp/compilation compilation-noarch --outputDir /tmp/compilation --target noarch --version 22.3.0
```