### PR TITLE
Fix dependency testing when patch version is zero.

### DIFF
--- a/dependency/README.md
+++ b/dependency/README.md
@@ -1,0 +1,48 @@
+# Dependency
+
+Pre-compiled distributions of Pip are provided for all linux stacks.
+
+This directory contains scripts and GitHub Actions to facilitate the following:
+* Identifying when there is a new version of Pip available
+* Compiling Pip for all supported stacks (i.e. `noarch`)
+
+## Running locally
+
+Running the steps locally can be useful for iterating on the compilation process
+(e.g. changing compilation options) as well as debugging.
+
+### Retrieval
+
+Retrieve latest versions with:
+
+```
+cd ./retrieval
+
+go run main.go \
+  --buildpack-toml-path ../../buildpack.toml \
+  --output /path/to/retrieved.json
+```
+
+See [retrieval/README.md](retrieval/README.md) for more details.
+
+### Compilation
+
+To compile:
+
+```
+docker build \
+  --tag pip-compilation-noarch \
+  --file ./actions/compile/noarch.Dockerfile \
+  ./actions/compile
+
+output_dir=$(mktemp -d)
+
+docker run \
+  --volume $output_dir:/tmp/compilation \
+  pip-compilation-noarch \
+    --outputDir /tmp/compilation \
+    --target noarch \
+    --version 23.0.1
+```
+
+See [actions/compile/README.md](actions/compile/README.md) for more details.

--- a/dependency/actions/compile/README.md
+++ b/dependency/actions/compile/README.md
@@ -4,15 +4,23 @@ Running compilation locally:
 
 1. Build the build environment:
 ```shell
-docker build --tag compilation-noarch --file noarch.Dockerfile .
+docker build \
+  --tag pip-compilation-noarch \
+  --file noarch.Dockerfile \
+  .
 ```
 
-2. Make the output directory:
+2. Make a directory for the compiled output:
 ```shell
 output_dir=$(mktemp -d)
 ```
 
-3. Run compilation and use a volume mount to access it:
+3. Run compilation and use a volume mount to access the output directory:
 ```shell
-docker run --volume $output_dir:/tmp/compilation compilation-noarch --outputDir /tmp/compilation --target noarch --version 22.2.2
+docker run \
+  --volume $output_dir:/tmp/compilation \
+  pip-compilation-noarch \
+  --outputDir /tmp/compilation \
+  --target noarch \
+  --version 22.2.2
 ```

--- a/dependency/retrieval/README.md
+++ b/dependency/retrieval/README.md
@@ -1,0 +1,36 @@
+# Dependency Retrieval
+
+## Running locally
+
+Run the following command:
+
+```
+go run main.go \
+  --buildpack-toml-path ../../buildpack.toml \
+  --output /path/to/retrieved.json
+```
+
+Example output (abbreviated for clarity):
+
+```
+Found 123 versions of pip from upstream
+[
+  "23.0.1", "23.0.0", [...],  "0.2.0"
+]
+Found 123 versions of pip for constraint *
+[
+  "23.0.1", "23.0.0", [...],  "0.2.0"
+]
+Found 2 versions of pip newer than '22.3.1' for constraint *, after limiting for 2 patches
+[
+  "23.0.1", "23.0.0"
+]
+Found 2 versions of pip as new versions
+[
+  "23.0.1", "23.0.0"
+]
+Generating metadata for 23.0.1, with targets [noarch]
+Generating metadata for 23.0.0, with targets [noarch]
+Wrote metadata to /path/to/retrieved.json
+
+```

--- a/dependency/test/test.sh
+++ b/dependency/test/test.sh
@@ -14,6 +14,13 @@ extract_tarball() {
 
 check_version() {
   expected_version="$1"
+
+  if [[ "${expected_version}" =~ [0-9]+.[0-9]+.0 ]]; then
+    new_expected_version="$(echo "${expected_version}" | cut -d '.' -f1,2)"
+    echo "expected version ${expected_version} has '0' for patch - using 'Major.Minor' format instead (i.e.: '${new_expected_version}')"
+    expected_version="${new_expected_version}"
+  fi
+
   actual_version="$(python3 ./pip/setup.py  --version)"
   if [[ "${actual_version}" != "${expected_version}" ]]; then
     echo "Version ${actual_version} does not match expected version ${expected_version}"


### PR DESCRIPTION
## Summary / Use Cases

This PR fixes the dependency compilation tests to handle the case where the patch version is `0` (e.g. `23.0.0`).
We need this because Pip does not strictly follow semver; it drops the patch version when it is `0`. So pip version 23.0.0 is actually v23.0

This resolves #377 .

This PR also adds/updates the READMEs for dependency compilation.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
