### PR TITLE
Add flit_core dependency.

### DIFF
--- a/dependency/actions/compile/entrypoint
+++ b/dependency/actions/compile/entrypoint
@@ -66,6 +66,7 @@ function main() {
     pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: pip=="${version}"
     pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: wheel
     pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: setuptools
+    pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: flit_core
 
     # Use globbing to detect the pip tarball
     # https://github.com/paketo-buildpacks/pip/issues/334


### PR DESCRIPTION
## Summary / Use Cases

This PR adds `flit_core` to the vendored dependencies. This is required to use pip `23.0.x` in an offline capacity.

See failures in #390 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
