### PR TITLE
Add --no-index to ensure pip install is offline

### DIFF
--- a/pip_install_process.go
+++ b/pip_install_process.go
@@ -32,7 +32,7 @@ func (p PipInstallProcess) Execute(srcPath, targetLayerPath string) error {
 
 	err := p.executable.Execute(pexec.Execution{
 		// Install pip from source with the pip that comes pre-installed with cpython
-		Args: []string{"-m", "pip", "install", srcPath, "--user", fmt.Sprintf("--find-links=%s", srcPath)},
+		Args: []string{"-m", "pip", "install", srcPath, "--user", "--no-index", fmt.Sprintf("--find-links=%s", srcPath)},
 		// Set the PYTHONUSERBASE to ensure that pip is installed to the newly created target layer.
 		Env:    append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", targetLayerPath)),
 		Stdout: buffer,

--- a/pip_install_process_test.go
+++ b/pip_install_process_test.go
@@ -45,7 +45,7 @@ func testPipInstallProcess(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(executable.ExecuteCall.Receives.Execution.Env).To(Equal(append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", targetLayerPath))))
-				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"-m", "pip", "install", srcLayerPath, "--user", fmt.Sprintf("--find-links=%s", srcLayerPath)}))
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"-m", "pip", "install", srcLayerPath, "--user", "--no-index", fmt.Sprintf("--find-links=%s", srcLayerPath)}))
 			})
 		})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves https://github.com/paketo-buildpacks/pip/issues/409

Adds the `--no-index` flag to the pip installation to ensure it does not check remote repositories during the installation.

Relevant pip documentation:

> pip looks for packages in a number of places: on PyPI (if not disabled via --no-index), in the local filesystem, and in any additional repositories specified via --find-links or --index-url. There is no ordering in the locations that are searched. Rather they are all checked, and the “best” match for the requirements (in terms of version number - see [PEP 440](https://peps.python.org/pep-0440/) for details) is selected.

[Source](https://pip.pypa.io/en/stable/cli/pip_install/#finding-packages)


## Use Cases
<!-- An explanation of the use cases your change enables -->

In air-gapped environments where unallowed network calls time out rather than immediately reject (ex. a Kubernetes cluster with Network Policies), attempting to read from the PyPI index can result in slow builds.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary. (An integration test with a slow network would be great here, but doesn't seem like rigging is in place for a test like that)
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
