### PR TITLE
Persist pip-source layer; add layer path to PIP_FIND_LINKS env var

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -3,6 +3,8 @@ package pip
 // Pip is the name of the layer into which pip dependency is installed.
 const Pip = "pip"
 
+const PipSrc = "pip-source"
+
 // CPython is the name of the python runtime dependency provided by the CPython buildpack: https://github.com/paketo-buildpacks/cpython
 const CPython = "cpython"
 


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->
The changes in this PR ensure that we persist the extracted `pip` source code in a layer which is available to downstream buildpacks at build-time instead of an ephemeral directory so that invocations of `pip install` may reliably access the packages bundled therein (setuptools, wheel, etc.). Setting the `PIP_FIND_LINKS` environment variable ensures that the `pip-install` buildpack can see the location of the `pip` source without explicit coupling.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Resolves #421 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
