### PR TITLE
dep/comp: download pip with latest pip

### DIFF
--- a/dependency/actions/compile/entrypoint
+++ b/dependency/actions/compile/entrypoint
@@ -59,6 +59,9 @@ function main() {
   echo "download_dir=${download_dir}"
 
   pip3 --version
+  # "pip download pip" with older pips have seen failures that say "has inconsistent name: filename has 'pip', but metadata has 'unknown'"
+  pip3 install --upgrade pip
+  pip3 --version
   python3 --version
 
   pushd "${download_dir}" > /dev/null


### PR DESCRIPTION
The ubuntu:jammy image does not come with latest pip (or python). When using an older pip to download the new pip, we are seeing failures like
https://github.com/paketo-buildpacks/pip/actions/runs/8452987604/job/23154821820#step:4:996: (
```
Requested unknown from https://files.pythonhosted.org/packages/94/59/6638090c25e9bc4ce0c42817b5a234e183872a1129735a9330c472cc2056/pip-24.0.tar.gz#sha256=ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2 has inconsistent name: filename has 'pip', but metadata has 'unknown' 
```
)

Resolves https://github.com/paketo-buildpacks/pip/issues/377
