### PR TITLE
Revert "Add targets to buildpack.toml"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -44,11 +44,3 @@ api = "0.7"
 
 [[stacks]]
   id = "*"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "18.04"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "22.04"


### PR DESCRIPTION
This reverts commit ab480267f338a8c37239c598963c104a3eec15ed.

 - This change was made in error. We can re-evaluate introducing targets when we bump the buildpack API spec.
