### PR TITLE
dep tests: 'python setup.py --version' is deprecated

### DIFF
--- a/dependency/test/README.md
+++ b/dependency/test/README.md
@@ -9,11 +9,6 @@ docker run -it \
   ubuntu:jammy \
   bash
 
-# Now on the container
-# This is not required on Github Actions Virtual Environments
-# https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
-apt-get update && apt-get install python3 -y
-
 # Passing
 $ /tmp/test/test.sh \
   --tarballPath /tmp/output_dir/pip_22.2.2_noarch_ff717ff0.tgz \

--- a/dependency/test/test.sh
+++ b/dependency/test/test.sh
@@ -21,7 +21,7 @@ check_version() {
     expected_version="${new_expected_version}"
   fi
 
-  actual_version="$(python3 ./pip/setup.py  --version)"
+  actual_version="$(grep -e "^Version:" pip/PKG-INFO | awk -F ': ' '{print $2}')"
   if [[ "${actual_version}" != "${expected_version}" ]]; then
     echo "Version ${actual_version} does not match expected version ${expected_version}"
     exit 1
@@ -67,8 +67,6 @@ main() {
 
   echo "tarballPath=${tarballPath}"
   echo "expectedVersion=${expectedVersion}"
-
-  apt-get update && apt-get install python3-setuptools -y
 
   extract_tarball "${tarballPath}"
   check_version "${expectedVersion}"


### PR DESCRIPTION
and 24.0 seems like it removed support for it.
See https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#python-setup-py-version

Should fix https://github.com/paketo-buildpacks/pip/actions/runs/9319330801/job/25653740927#step:6:21
