### PR TITLE
Start building and publishing multi-arch buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 The Paketo Buildpack for Pip is a Cloud Native Buildpack that installs pip into a
 layer and places it on the `PATH`.
 
-The buildpack is published for consumption at `gcr.io/paketo-buildpacks/pip` and
-`paketobuildpacks/pip`.
+The buildpack is published for consumption at `paketobuildpacks/pip`.
 
 ## Behavior
 This buildpack always participates.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -10,8 +10,17 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/pip/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
-  pre-package = "./scripts/build.sh"
+  include-files = [
+    "buildpack.toml",
+    "linux/amd64/bin/build",
+    "linux/amd64/bin/detect",
+    "linux/amd64/bin/run",
+    "linux/arm64/bin/build",
+    "linux/arm64/bin/detect",
+    "linux/arm64/bin/run",
+  ]
+
+  pre-package = "./scripts/build.sh --target linux/amd64 --target linux/arm64"
 
   [[metadata.dependencies]]
     checksum = "sha256:e100bda0c7e0dd20c6a471dbddb027698c3a96263fe7c0d5c196953eb8e82281"
@@ -44,3 +53,11 @@ api = "0.7"
 
 [[stacks]]
   id = "*"
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"

--- a/integration.json
+++ b/integration.json
@@ -4,6 +4,6 @@
     "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest",
     "index.docker.io/jericop/amazonlinux-builder:base"
   ],
-  "cpython":"github.com/paketo-buildpacks/cpython",
-  "build-plan":"github.com/paketo-community/build-plan"
+  "cpython":"index.docker.io/paketobuildpacks/cpython",
+  "build-plan":"index.docker.io/paketocommunity/build-plan"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change does the following:
*  Updates buildpack.toml to start building and publishing multi-arch bulidpacks
* Updates `integration.json` so buildpacks needed for integration tests are pulled from registry URIs rather than from GitHub releases
* Remove reference to GCR in readme

## Use Cases
<!-- An explanation of the use cases your change enables -->
multi-arch 🥳 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
