### PR TITLE
fix: grab correct version of flit-core when building tar file

### DIFF
--- a/dependency/actions/compile/constraints.py
+++ b/dependency/actions/compile/constraints.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+import tomllib
+
+file_path = sys.argv[1]
+
+with open(file_path, "rb") as f:
+    data = tomllib.load(f)
+    requires = data["build-system"]["requires"][0]
+    _, constraints = requires.split(" ")
+    print(constraints)

--- a/dependency/actions/compile/entrypoint
+++ b/dependency/actions/compile/entrypoint
@@ -59,23 +59,22 @@ function main() {
   echo "download_dir=${download_dir}"
 
   pip3 --version
-  # "pip download pip" with older pips have seen failures that say "has inconsistent name: filename has 'pip', but metadata has 'unknown'"
-  pip3 install --upgrade pip
-  pip3 --version
   python3 --version
 
   pushd "${download_dir}" > /dev/null
     mkdir -p /tmp/pip-cache/
     pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: pip=="${version}"
-    pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: wheel
-    pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: setuptools
-    pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: flit_core
 
     # Use globbing to detect the pip tarball
     # https://github.com/paketo-buildpacks/pip/issues/334
     tar --extract \
       --strip-components=1 \
       --file pip-*.tar.gz
+
+    flit_core_constraints=$(python3 /constraints.py pyproject.toml)
+    pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: wheel
+    pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: setuptools
+    pip3 --cache-dir=/tmp/pip-cache/ download --no-binary :all: flit_core${flit_core_constraints}
 
     tar --create \
       --gunzip \

--- a/dependency/actions/compile/noarch.Dockerfile
+++ b/dependency/actions/compile/noarch.Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV LC_CTYPE = 'en_US.UTF'
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LC_CTYPE='en_US.UTF'
 
 RUN apt-get update && apt install python3-pip -y
 
 COPY entrypoint /entrypoint
+COPY constraints.py /constraints.py
 
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The script currently grabs the latest version of flit-core
which at this time does not match the constraints set in the
pyproject.

Use the build-system requires entry to download a version that
matches the constraints.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Fix the compiled dependencies automated update job.
The job currently succeeds but creates an unusable tar ball.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
